### PR TITLE
固定データを抜き出してregDeathLog関数をリファクタリング

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -1,0 +1,67 @@
+module.exports = {
+    deaths: {
+        lava: [
+            {regex: /(.*?) tried to swim in lava while trying to escape (.*?)/, trans: ''},
+            {regex: /(.*?) tried to swim in lava/, trans: ''},
+        ],
+        fell: [
+            {regex: /(.*?) fell from a high place/, trans: ''},
+            {regex: /(.*?) fell off a ladder/, trans: ''},
+            {regex: /(.*?) fell off some vines/, trans: ''},
+            {regex: /(.*?) fell out of the world/, trans: ''},
+            {regex: /(.*?) fell out of the water/, trans: ''},
+            {regex: /(.*?) fell into a patch of fire/, trans: ''},
+            {regex: /(.*?) fell into a patch of cacti/, trans: ''},
+            {regex: /(.*?) fell from a high place and fell out of the world/, trans: ''}
+        ],
+        shot: [
+            {regex: /(.*?) was shot by arrow/, trans: ''},
+            {regex: /(.*?) was shot by (.*?)/, trans: ''},
+            {regex: /(.*?) was shot by (.*?) using (.*?)/, trans: ''},
+            {regex: /(.*?) was shot off some vines by (.*?)/, trans: ''},
+            {regex: /(.*?) was shot off a ladder by (.*?)/, trans: ''}
+        ],
+        killed: [
+            {regex: /(.*?) was killed by magic/, trans: ''},
+            {regex: /(.*?) was killed by (.*?) using magic/, trans: ''},
+            {regex: /(.*?) was killed while trying to hurt (.*?)/, trans: ''}
+        ],
+        slain: [
+            {regex: /(.*?) was slain by (.*?) using (.*?)/, trans: ''},
+            {regex: /(.*?) was slain by (.*?)/, trans: ''}
+        ],
+        was: [
+            {regex: /(.*?) was squashed by a falling anvil/, trans: ''},
+            {regex: /(.*?) was pricked to death/, trans: ''},
+            {regex: /(.*?) was pummeled by (.*?)/, trans: ''},
+            {regex: /(.*?) was doomed to fall/, trans: ''},
+            {regex: /(.*?) was blown up by (.*?)/, trans: ''},
+            {regex: /(.*?) was blown from a high place by (.*?)/, trans: ''},
+            {regex: /(.*?) was burnt to a crisp whilst fighting (.*?)/, trans: ''},
+            {regex: /(.*?) was knocked into the void by (.*?)/, trans: ''},
+            {regex: /(.*?) was fireballed by (.*?)/, trans: ''},
+            {regex: /(.*?) was squashed by a falling block/, trans: ''}
+        ],
+        walked: [
+            {regex: /(.*?) walked into a cactus whilst trying to escape (.*?)/, trans: ''},
+            {regex: /(.*?) walked into a fire whilst fighting (.*?)/, trans: ''}
+        ],
+        drowned: [
+            {regex: /(.*?) drowned whilst trying to escape (.*?)/, trans: ''},
+            {regex: /(.*?) drowned/, trans: ''}
+        ],
+        death: [
+            {regex: /(.*?) burned to death/, trans: ''},
+            {regex: /(.*?) starved to death/, trans: ''}
+        ],
+        other: [
+            {regex: /(.*?) died/, trans: ''},
+            {regex: /(.*?) suffocated in a wall/, trans: ''},
+            {regex: /(.*?) blew up/, trans: ''},
+            {regex: /(.*?) hit the ground too hard/, trans: ''},
+            {regex: /(.*?) got finished off by (.*?) using (.*?)/, trans: ''},
+            {regex: /(.*?) went up in flames/, trans: ''},
+            {regex: /(.*?) withered away/, trans: ''}
+        ]
+    }
+};

--- a/lib/minecraft-log-parse.js
+++ b/lib/minecraft-log-parse.js
@@ -1,5 +1,11 @@
 'use strict';
 
+const _deaths = require('./data').deaths;
+const deaths = []; // [{name, regex, trans}]
+Object.keys(_deaths).forEach(name => {
+    _deaths[name].forEach(({regex, trans}) => deaths.push({name, regex, trans}));
+});
+
 module.exports = class {
     constructor() {
         this.data = null;
@@ -142,28 +148,13 @@ module.exports = class {
      */
 
     regDeathLog(text) {
-        let breakdown;
-        if(text.indexOf('lava')!==-1)
-            breakdown = text.match(/(.*?) tried to swim in lava|(.*?) tried to swim in lava while trying to escape (.*?)/);
-        else if(text.indexOf('fell')!==-1)
-            breakdown = text.match(/(.*?) fell from a high place|(.*?) fell off a ladder|(.*?) fell off some vines|(.*?) fell out of the world|(.*?) fell out of the water|(.*?) fell into a patch of fire|(.*?) fell into a patch of cacti|(.*?) fell from a high place and fell out of the world/);
-        else if(text.indexOf('shot')!==-1)
-            breakdown = text.match(/(.*?) was shot by arrow|(.*?) was shot by arrow|(.*?) was shot by (.*?)|(.*?) was shot by (.*?) using (.*?)|(.*?) was shot off some vines by (.*?)|(.*?) was shot off a ladder by (.*?)/);
-        else if(text.indexOf('killed')!==-1)
-            breakdown = text.match(/(.*?) was killed by magic|(.*?) was killed by (.*?) using magic|(.*?) was killed while trying to hurt (.*?)/);
-        else if(text.indexOf('slain')!==-1)
-            breakdown = text.match(/(.*?) was slain by (.*?)|(.*?) was slain by (.*?) using (.*?)/);
-        else if(text.indexOf('was')!==-1)
-            breakdown = text.match(/(.*?) was squashed by a falling anvil|(.*?) was pricked to death|(.*?) was pummeled by (.*?)|(.*?) was doomed to fall|(.*?) was blown up by (.*?)|(.*?) was blown from a high place by (.*?)|(.*?) was burnt to a crisp whilst fighting (.*?)|(.*?) was knocked into the void by (.*?)|(.*?) was fireballed by (.*?)|(.*?) was squashed by a falling block/);
-        else if(text.indexOf('walked')!==-1)
-            breakdown = text.match(/(.*?) walked into a cactus whilst trying to escape (.*?)|(.*?) walked into a fire whilst fighting (.*?)/);
-        else if(text.indexOf('drowned')!==-1)
-            breakdown = text.match(/(.*?) drowned|(.*?) drowned whilst trying to escape (.*?)/);
-        else if(text.indexOf('death')!==-1)
-            breakdown = text.match(/|(.*?) burned to death|(.*?) starved to death/);
-        else
-            breakdown = text.match(/(.*?) died|(.*?) suffocated in a wall|(.*?) blew up|(.*?) hit the ground too hard|(.*?) got finished off by (.*?) using (.*?)|(.*?) went up in flames|(.*?) withered away/);
-        return breakdown;
+        const death = deaths.find(({regex}) => regex.test(text));
+        if (!death) return null;
+
+        const matched = text.match(death.regex);
+        // do something
+
+        return matched;
     }
 
     isset(data) {

--- a/lib/minecraft-log-parse.js
+++ b/lib/minecraft-log-parse.js
@@ -3,7 +3,7 @@
 const _deaths = require('./data').deaths;
 const deaths = []; // [{name, regex, trans}]
 Object.keys(_deaths).forEach(name => {
-    _deaths[name].forEach(({regex, trans}) => deaths.push({name, regex, trans}));
+    _deaths[name].forEach(x => deaths.push({name, regex: x.regex, trans: x.trans}));
 });
 
 module.exports = class {
@@ -148,7 +148,7 @@ module.exports = class {
      */
 
     regDeathLog(text) {
-        const death = deaths.find(({regex}) => regex.test(text));
+        const death = deaths.find(x => x.regex.test(text));
         if (!death) return null;
 
         const matched = text.match(death.regex);


### PR DESCRIPTION
`lib/data.js` を作って、deathsプロパティに死因や正規表現を抜き出した。
transプロパティは拡張性のためのダミー。 `"$1 は死にました"` みたいなの入れると日本語変換しやすいかも。
`lib/minecraft-log-parse.js` の先頭で読み込みとリスト化して、 `regDeathLog` では回すだけ。
_＼テストはしてない／_
